### PR TITLE
Implement role registry change for AVS smart contracts

### DIFF
--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -12,9 +12,15 @@ contract DeployAvsContracts is Script {
 
     function run() public {
 
+        // TODO: set me
+        address roleRegistry = address(0x0);
+        assert(roleRegistry != address(0x0));
+        address avsOperatorManager = address(0x0);
+        assert(avsOperatorManager != address(0x0));
+
         vm.startBroadcast(address(0xf8a86ea1Ac39EC529814c377Bd484387D395421e));
-        address newManagerImpl = address(new AvsOperatorManager());
-        address newOperatorImpl = address(new AvsOperator());
+        address newManagerImpl = address(new AvsOperatorManager(roleRegistry));
+        address newOperatorImpl = address(new AvsOperator(avsOperatorManager, roleRegistry));
 
         console2.log("New manager:", newManagerImpl);
         console2.log("New operator:", newOperatorImpl);

--- a/script/upgrade.s.sol
+++ b/script/upgrade.s.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import "../src/AvsOperator.sol";
+import "../src/AvsOperatorManager.sol";
+
+import "forge-std/console2.sol";
+
+contract DeployAvsContracts is Script {
+
+    function run() public {
+
+        // TODO: set me
+        address roleRegistry = address(0x0);
+        assert(roleRegistry != address(0x0));
+
+        // TESTNET
+        vm.selectFork(vm.createFork(vm.envString("HOLESKY_RPC_URL")));
+        AvsOperatorManager avsOperatorManager = AvsOperatorManager(address(0xDF9679E8BFce22AE503fD2726CB1218a18CD8Bf4));
+
+        // sanity check
+        address sanityOperator = address(avsOperatorManager.avsOperators(1));
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy new implementations
+        address newManagerImpl = address(new AvsOperatorManager(roleRegistry));
+        address newOperatorImpl = address(new AvsOperator(address(avsOperatorManager), roleRegistry));
+
+        // original version was deployed with an older version of UUPS upgradeable
+        // I can can use the new version after the first upgrade
+        //avsOperatorManager.upgradeToAndCall(address(new AvsOperatorManager()), "");
+
+        bytes4 selector = bytes4(keccak256(bytes("upgradeTo(address)")));
+        bytes memory data = abi.encodeWithSelector(selector, newManagerImpl);
+        (bool success, ) = address(avsOperatorManager).call(data);
+        require(success, "Call failed");
+
+        avsOperatorManager.upgradeEtherFiAvsOperator(address(newOperatorImpl));
+
+        console2.log("New managerImpl:", newManagerImpl);
+        console2.log("New operatorImpl:", newOperatorImpl);
+        vm.stopBroadcast();
+
+        // sanity check that contract still works and storage didn't shift
+        assert(sanityOperator == address(avsOperatorManager.avsOperators(1)));
+
+    }
+}

--- a/src/AvsOperatorManager.sol
+++ b/src/AvsOperatorManager.sol
@@ -9,6 +9,7 @@ import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import "./AvsOperator.sol";
+import "./IRoleRegistry.sol";
 
 import "./eigenlayer-interfaces/IAVSDirectory.sol";
 import "./eigenlayer-interfaces/IServiceManager.sol";
@@ -26,8 +27,8 @@ contract AvsOperatorManager is
 
     IDelegationManager public delegationManager;
 
-    mapping(address => bool) public admins;
-    mapping(address => bool) public pausers;
+    mapping(address => bool) public DEPRECATED_admins;
+    mapping(address => bool) public DEPRECATED_pausers;
 
     IAVSDirectory public avsDirectory;
 
@@ -35,18 +36,19 @@ contract AvsOperatorManager is
     // allowed calls that AvsRunner can trigger from operator contract
     mapping(uint256 => mapping(address => mapping(bytes4 => bool))) public allowedOperatorCalls;
 
+    IRoleRegistry public immutable roleRegistry;
+
     event ForwardedOperatorCall(uint256 indexed id, address indexed target, bytes4 indexed selector, bytes data, address sender);
     event CreatedEtherFiAvsOperator(uint256 indexed id, address etherFiAvsOperator);
     event RegisteredAsOperator(uint256 indexed id, IDelegationManager.OperatorDetails detail);
     event ModifiedOperatorDetails(uint256 indexed id, IDelegationManager.OperatorDetails newOperatorDetails);
     event UpdatedOperatorMetadataURI(uint256 indexed id, string metadataURI);
     event UpdatedAvsNodeRunner(uint256 indexed id, address avsNodeRunner);
-    event UpdatedEcdsaSigner(uint256 indexed id, address ecdsaSigner);
     event AllowedOperatorCallsUpdated(uint256 indexed id, address indexed target, bytes4 indexed selector, bool allowed);
-    event AdminUpdated(address indexed admin, bool isAdmin);
 
      /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _roleRegistry) {
+        roleRegistry = IRoleRegistry(_roleRegistry);
         _disableInitializers();
     }
 
@@ -66,7 +68,12 @@ contract AvsOperatorManager is
         avsDirectory = IAVSDirectory(_avsDirectory);
     }
 
+    //--------------------------------------------------------------------------------------
+    //-------------------------------------  ROLES  ---------------------------------------
+    //--------------------------------------------------------------------------------------
 
+    bytes32 constant public ECDSA_SIGNER_ROLE = keccak256("AOM_ECDSA_SIGNER_ROLE");
+    bytes32 constant public AVS_OPERATOR_ADMIN_ROLE = keccak256("AOM_AVS_OPERATOR_ADMIN_ROLE");
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  Eigenlayer Core  ----------------------------------
@@ -95,15 +102,16 @@ contract AvsOperatorManager is
     //--------------------------------------------------------------------------------------
 
     error InvalidOperatorCall();
+    error InvalidCaller();
 
     // Forward an arbitrary call to be run by the operator conract.
     // That operator must be approved for the specific method and target
-    function forwardOperatorCall(uint256 _id, address _target, bytes4 _selector, bytes calldata _args) external onlyOperator(_id) {
+    function forwardOperatorCall(uint256 _id, address _target, bytes4 _selector, bytes calldata _args) external {
         _forwardOperatorCall(_id, _target, _selector, _args);
     }
 
     // alternative version where you just pass raw input. Not sure which will end up being more convenient
-    function forwardOperatorCall(uint256 _id, address _target, bytes calldata _input) external onlyOperator(_id) {
+    function forwardOperatorCall(uint256 _id, address _target, bytes calldata _input) external {
 
         if (_input.length < 4) revert InvalidOperatorCall();
 
@@ -114,6 +122,7 @@ contract AvsOperatorManager is
     }
 
     function _forwardOperatorCall(uint256 _id, address _target, bytes4 _selector, bytes calldata _args) private {
+        if (!canForwardCall(_id)) revert InvalidCaller();
         if (!isValidOperatorCall(_id, _target, _selector, _args)) revert InvalidOperatorCall();
 
         avsOperators[_id].forwardCall(_target, abi.encodePacked(_selector, _args));
@@ -148,19 +157,9 @@ contract AvsOperatorManager is
         emit AllowedOperatorCallsUpdated(_operatorId, _target, _selector, _allowed);
     }
 
-    function updateAdmin(address _address, bool _isAdmin) external onlyOwner {
-        admins[_address] = _isAdmin;
-        emit AdminUpdated(_address, _isAdmin);
-    }
-
     function updateAvsNodeRunner(uint256 _id, address _avsNodeRunner) external onlyAdmin {
         avsOperators[_id].updateAvsNodeRunner(_avsNodeRunner);
         emit UpdatedAvsNodeRunner(_id, _avsNodeRunner);
-    }
-
-    function updateEcdsaSigner(uint256 _id, address _ecdsaSigner) external onlyAdmin {
-        avsOperators[_id].updateEcdsaSigner(_ecdsaSigner);
-        emit UpdatedEcdsaSigner(_id, _ecdsaSigner);
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
@@ -182,7 +181,6 @@ contract AvsOperatorManager is
 
         BeaconProxy proxy = new BeaconProxy(address(upgradableBeacon), "");
         avsOperators[_id] = AvsOperator(address(proxy));
-        avsOperators[_id].initialize(address(this));
 
         emit CreatedEtherFiAvsOperator(_id, address(avsOperators[_id]));
 
@@ -203,19 +201,14 @@ contract AvsOperatorManager is
         return avsOperators[_id].avsNodeRunner();
     }
 
-    function ecdsaSigner(uint256 _id) external view returns (address) {
-        return avsOperators[_id].ecdsaSigner();
-    }
-
     function operatorDetails(uint256 _id) external view returns (IDelegationManager.OperatorDetails memory) {
         return delegationManager.operatorDetails(address(avsOperators[_id]));
     }
 
-    // DEPRECATED
-    function getAvsInfo(uint256 _id, address _avsRegistryCoordinator) external view returns (AvsOperator.AvsInfo memory) {
-         return avsOperators[_id].getAvsInfo(_avsRegistryCoordinator);
+    function canForwardCall(uint256 _id) public view returns (bool) {
+        // only can forward call to operator contract if an admin, or the registered node runner
+        return (msg.sender == avsOperators[_id].avsNodeRunner() || roleRegistry.hasRole(AVS_OPERATOR_ADMIN_ROLE, msg.sender));
     }
-
 
     /**
      * @notice Calculates the digest hash to be signed by an operator to register with an AVS
@@ -233,22 +226,11 @@ contract AvsOperatorManager is
     //------------------------------------  Modifiers  -------------------------------------
     //--------------------------------------------------------------------------------------
 
-    function _onlyAdmin() internal view {
-        require(admins[msg.sender] || msg.sender == owner(), "INCORRECT_CALLER");
-    }
-
-    function _onlyOperator(uint256 _id) internal view {
-        require(msg.sender == avsOperators[_id].avsNodeRunner() || admins[msg.sender] || msg.sender == owner(), "INCORRECT_CALLER");
-    }
 
     modifier onlyAdmin() {
-        _onlyAdmin();
+        if (!roleRegistry.hasRole(AVS_OPERATOR_ADMIN_ROLE, msg.sender)) revert InvalidCaller();
         _;
     }
 
-    modifier onlyOperator(uint256 _id) {
-        _onlyOperator(_id);
-        _;
-    }
 
 }

--- a/src/AvsOperatorManager.sol
+++ b/src/AvsOperatorManager.sol
@@ -72,7 +72,6 @@ contract AvsOperatorManager is
     //-------------------------------------  ROLES  ---------------------------------------
     //--------------------------------------------------------------------------------------
 
-    bytes32 constant public ECDSA_SIGNER_ROLE = keccak256("AOM_ECDSA_SIGNER_ROLE");
     bytes32 constant public AVS_OPERATOR_ADMIN_ROLE = keccak256("AOM_AVS_OPERATOR_ADMIN_ROLE");
 
     //--------------------------------------------------------------------------------------

--- a/src/IRoleRegistry.sol
+++ b/src/IRoleRegistry.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IRoleRegistry {
+
+     /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+}

--- a/test/EigenDA.t.sol
+++ b/test/EigenDA.t.sol
@@ -18,8 +18,7 @@ contract EigenDATest is TestSetup, BlsTestHelper {
         uint256 signerKey = 0x1234abcd;
         {
             address signer = vm.addr(signerKey);
-            vm.prank(admin);
-            avsOperatorManager.updateEcdsaSigner(operatorId, signer);
+            roleRegistry.grantRole(AvsOperator(operator).ECDSA_SIGNER_ROLE(), signer);
         }
 
         // generate + sign the pubkey registration params with BLS key

--- a/test/mocks/RoleRegistryMock.sol
+++ b/test/mocks/RoleRegistryMock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../../src/IRoleRegistry.sol";
+
+contract RoleRegistryMock is IRoleRegistry {
+
+    mapping(bytes32 => mapping(address => bool)) public roles;
+    string public test = "hello";
+
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    constructor() {}
+
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return roles[role][account];
+    }
+
+    function grantRole(bytes32 role, address account) external {
+        if (!hasRole(role, account)) {
+            roles[role][account] = true;
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) external {
+        if (hasRole(role, account)) {
+            roles[role][account] = false;
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+}


### PR DESCRIPTION
Granular roles also lets us configure multiple ECDSA signers which wasn't possible before.