### PR TITLE
feat: Tier B hard contract disable — block AllocationManager calls

### DIFF
--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -22,3 +22,34 @@ contract DeployAvsContracts is Script {
 
     }
 }
+
+/// @notice Deploys a new AvsOperatorManager implementation and logs the upgradeToAndCall
+/// calldata needed to upgrade the proxy and initialize the AllocationManager block.
+/// The actual upgrade transaction must be executed by the proxy owner (multisig / timelock).
+contract DeployTierBUpgrade is Script {
+
+    // TODO(deploy): replace with the confirmed EigenLayer AllocationManager proxy address
+    address constant ALLOCATION_MANAGER = address(0);
+
+    function run() public {
+        require(ALLOCATION_MANAGER != address(0), "Set ALLOCATION_MANAGER before deploying");
+
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(pk);
+        address newManagerImpl = address(new AvsOperatorManager());
+        vm.stopBroadcast();
+
+        bytes memory initData = abi.encodeCall(AvsOperatorManager.initializeV2, (ALLOCATION_MANAGER));
+        bytes memory upgradeCalldata = abi.encodeWithSignature(
+            "upgradeToAndCall(address,bytes)",
+            newManagerImpl,
+            initData
+        );
+
+        console2.log("New implementation:", newManagerImpl);
+        console2.log("AllocationManager blocked:", ALLOCATION_MANAGER);
+        console2.log("upgradeToAndCall calldata:");
+        console2.logBytes(upgradeCalldata);
+    }
+}

--- a/src/AvsOperatorManager.sol
+++ b/src/AvsOperatorManager.sol
@@ -35,6 +35,10 @@ contract AvsOperatorManager is
     // allowed calls that AvsRunner can trigger from operator contract
     mapping(uint256 => mapping(address => mapping(bytes4 => bool))) public allowedOperatorCalls;
 
+    // Blocked target — all forward calls to this address revert.
+    // Write-once via initializeV2; removal requires a full UUPS upgrade.
+    address public blockedAllocationManager;
+
     event ForwardedOperatorCall(uint256 indexed id, address indexed target, bytes4 indexed selector, bytes data, address sender);
     event CreatedEtherFiAvsOperator(uint256 indexed id, address etherFiAvsOperator);
     event RegisteredAsOperator(uint256 indexed id, IDelegationManager.OperatorDetails detail);
@@ -44,6 +48,7 @@ contract AvsOperatorManager is
     event UpdatedEcdsaSigner(uint256 indexed id, address ecdsaSigner);
     event AllowedOperatorCallsUpdated(uint256 indexed id, address indexed target, bytes4 indexed selector, bool allowed);
     event AdminUpdated(address indexed admin, bool isAdmin);
+    event AllocationManagerBlocked(address indexed allocationManager);
 
      /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -66,7 +71,12 @@ contract AvsOperatorManager is
         avsDirectory = IAVSDirectory(_avsDirectory);
     }
 
-
+    /// @notice One-shot initialization to block all forward calls to EigenLayer's AllocationManager.
+    /// No setter is provided — removal requires a full UUPS upgrade.
+    function initializeV2(address _allocationManager) external onlyOwner reinitializer(2) {
+        blockedAllocationManager = _allocationManager;
+        emit AllocationManagerBlocked(_allocationManager);
+    }
 
     //--------------------------------------------------------------------------------------
     //---------------------------------  Eigenlayer Core  ----------------------------------
@@ -95,6 +105,7 @@ contract AvsOperatorManager is
     //--------------------------------------------------------------------------------------
 
     error InvalidOperatorCall();
+    error SlashingPathBlocked();
 
     // Forward an arbitrary call to be run by the operator conract.
     // That operator must be approved for the specific method and target
@@ -114,6 +125,7 @@ contract AvsOperatorManager is
     }
 
     function _forwardOperatorCall(uint256 _id, address _target, bytes4 _selector, bytes calldata _args) private {
+        if (_target == blockedAllocationManager) revert SlashingPathBlocked();
         if (!isValidOperatorCall(_id, _target, _selector, _args)) revert InvalidOperatorCall();
 
         avsOperators[_id].forwardCall(_target, abi.encodePacked(_selector, _args));
@@ -122,7 +134,7 @@ contract AvsOperatorManager is
 
     // Forward an arbitrary call to be run by the operator conract. Admins can ignore the call whitelist
     function adminForwardCall(uint256 _id, address _target, bytes4 _selector, bytes calldata _args) external onlyAdmin {
-
+        if (_target == blockedAllocationManager) revert SlashingPathBlocked();
         avsOperators[_id].forwardCall(_target, abi.encodePacked(_selector, _args));
         emit ForwardedOperatorCall(_id, _target, _selector, _args, msg.sender);
     }
@@ -144,6 +156,7 @@ contract AvsOperatorManager is
 
     // specify which calls an node runner can make against which target contracts through the operator contract
     function updateAllowedOperatorCalls(uint256 _operatorId, address _target, bytes4 _selector, bool _allowed) external onlyAdmin {
+        if (_allowed && _target == blockedAllocationManager) revert SlashingPathBlocked();
         allowedOperatorCalls[_operatorId][_target][_selector] = _allowed;
         emit AllowedOperatorCallsUpdated(_operatorId, _target, _selector, _allowed);
     }

--- a/test/AvsOperatorManager.t.sol
+++ b/test/AvsOperatorManager.t.sol
@@ -163,4 +163,167 @@ contract EtherFiAvsOperatorsManagerTest is TestSetup, CryptoTestHelper {
         vm.expectRevert("RegistryCoordinator._registerOperator: operator already registered for some quorums being registered for");
         avsOperatorManager.forwardOperatorCall(operatorId, brevisRegistryCoordinator, selector, args);
     }
+
+    // -------------------------------------------------------------------------
+    //  Tier B — AllocationManager Block Tests
+    // -------------------------------------------------------------------------
+
+    address constant MOCK_ALLOCATION_MANAGER = address(0xABCD);
+
+    function _enableAllocationManagerBlock() internal {
+        vm.prank(admin);
+        avsOperatorManager.initializeV2(MOCK_ALLOCATION_MANAGER);
+    }
+
+    function test_adminForwardCallBlocksAllocationManager() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        bytes4 selector = bytes4(keccak256("registerForOperatorSets(address,(address,uint32[],bytes))"));
+        bytes memory args = hex"";
+
+        vm.prank(admin);
+        vm.expectRevert(AvsOperatorManager.SlashingPathBlocked.selector);
+        avsOperatorManager.adminForwardCall(operatorId, MOCK_ALLOCATION_MANAGER, selector, args);
+    }
+
+    function test_forwardOperatorCallBlocksAllocationManager() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        bytes4 selector = bytes4(keccak256("registerForOperatorSets(address,(address,uint32[],bytes))"));
+        bytes memory args = hex"";
+
+        vm.prank(operatorOneRunner);
+        vm.expectRevert(AvsOperatorManager.SlashingPathBlocked.selector);
+        avsOperatorManager.forwardOperatorCall(operatorId, MOCK_ALLOCATION_MANAGER, selector, args);
+    }
+
+    function test_forwardOperatorCallRawInputBlocksAllocationManager() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        bytes4 selector = bytes4(keccak256("registerForOperatorSets(address,(address,uint32[],bytes))"));
+        bytes memory rawInput = abi.encodePacked(selector, hex"00000000");
+
+        vm.prank(operatorOneRunner);
+        vm.expectRevert(AvsOperatorManager.SlashingPathBlocked.selector);
+        avsOperatorManager.forwardOperatorCall(operatorId, MOCK_ALLOCATION_MANAGER, rawInput);
+    }
+
+    function test_updateAllowedOperatorCallsBlocksAllocationManager() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        bytes4 selector = bytes4(keccak256("registerForOperatorSets(address,(address,uint32[],bytes))"));
+
+        vm.prank(admin);
+        vm.expectRevert(AvsOperatorManager.SlashingPathBlocked.selector);
+        avsOperatorManager.updateAllowedOperatorCalls(operatorId, MOCK_ALLOCATION_MANAGER, selector, true);
+    }
+
+    function test_updateAllowedOperatorCallsAllowsRemovingBlockedTarget() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        bytes4 selector = bytes4(keccak256("registerForOperatorSets(address,(address,uint32[],bytes))"));
+
+        vm.prank(admin);
+        avsOperatorManager.updateAllowedOperatorCalls(operatorId, MOCK_ALLOCATION_MANAGER, selector, false);
+    }
+
+    function test_normalAdminForwardCallStillWorks() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        address nonBlockedTarget = address(avsOperatorManager);
+        bytes4 selector = avsOperatorManager.owner.selector;
+        bytes memory args = hex"";
+
+        vm.prank(admin);
+        avsOperatorManager.adminForwardCall(operatorId, nonBlockedTarget, selector, args);
+    }
+
+    function test_normalForwardOperatorCallStillWorks() public {
+        _enableAllocationManagerBlock();
+
+        uint256 operatorId = 1;
+        address target = address(avsOperatorManager);
+        bytes4 selector = avsOperatorManager.owner.selector;
+        bytes memory args = hex"";
+
+        vm.prank(admin);
+        avsOperatorManager.updateAllowedOperatorCalls(operatorId, target, selector, true);
+
+        vm.prank(operatorOneRunner);
+        avsOperatorManager.forwardOperatorCall(operatorId, target, selector, args);
+    }
+
+    function test_initializeV2CannotBeCalledTwice() public {
+        _enableAllocationManagerBlock();
+
+        assertEq(avsOperatorManager.blockedAllocationManager(), MOCK_ALLOCATION_MANAGER);
+
+        vm.prank(admin);
+        vm.expectRevert("Initializable: contract is already initialized");
+        avsOperatorManager.initializeV2(address(0xDEAD));
+    }
+
+    function test_initializeV2OnlyOwner() public {
+        vm.prank(operatorOneRunner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        avsOperatorManager.initializeV2(MOCK_ALLOCATION_MANAGER);
+    }
+
+    function test_blockIsInactiveBeforeInitializeV2() public {
+        assertEq(avsOperatorManager.blockedAllocationManager(), address(0));
+
+        uint256 operatorId = 1;
+        address target = address(avsOperatorManager);
+        bytes4 selector = avsOperatorManager.owner.selector;
+
+        vm.prank(admin);
+        avsOperatorManager.adminForwardCall(operatorId, target, selector, hex"");
+    }
+
+    function test_upgradeV2PreservesStorageAndSetsBlock() public {
+        initializeRealisticFork(MAINNET_FORK);
+
+        uint256 previousNextAvsOperatorId = avsOperatorManager.nextAvsOperatorId();
+        address previousDelegationManager = address(avsOperatorManager.delegationManager());
+        address previousAvsDirectory = address(avsOperatorManager.avsDirectory());
+        address previousOperator = address(avsOperatorManager.avsOperators(1));
+        address previousNodeRunner = AvsOperator(previousOperator).avsNodeRunner();
+        address previousSigner = AvsOperator(previousOperator).ecdsaSigner();
+
+        assertEq(avsOperatorManager.blockedAllocationManager(), address(0));
+
+        address owner = avsOperatorManager.owner();
+        vm.startPrank(owner);
+
+        AvsOperatorManager newImpl = new AvsOperatorManager();
+        bytes memory initData = abi.encodeCall(AvsOperatorManager.initializeV2, (MOCK_ALLOCATION_MANAGER));
+        bytes4 upgradeSelector = bytes4(keccak256(bytes("upgradeToAndCall(address,bytes)")));
+        bytes memory upgradeData = abi.encodeWithSelector(upgradeSelector, address(newImpl), initData);
+        (bool success, ) = address(avsOperatorManager).call(upgradeData);
+        require(success, "upgradeToAndCall failed");
+
+        avsOperatorManager.upgradeEtherFiAvsOperator(address(new AvsOperator()));
+        vm.stopPrank();
+
+        assertEq(previousNextAvsOperatorId, avsOperatorManager.nextAvsOperatorId());
+        assertEq(previousDelegationManager, address(avsOperatorManager.delegationManager()));
+        assertEq(previousAvsDirectory, address(avsOperatorManager.avsDirectory()));
+
+        address updatedOperator = address(avsOperatorManager.avsOperators(1));
+        assertEq(previousOperator, updatedOperator);
+        assertEq(previousNodeRunner, AvsOperator(updatedOperator).avsNodeRunner());
+        assertEq(previousSigner, AvsOperator(updatedOperator).ecdsaSigner());
+
+        assertEq(avsOperatorManager.blockedAllocationManager(), MOCK_ALLOCATION_MANAGER);
+
+        vm.prank(owner);
+        vm.expectRevert(AvsOperatorManager.SlashingPathBlocked.selector);
+        avsOperatorManager.adminForwardCall(1, MOCK_ALLOCATION_MANAGER, bytes4(0), hex"");
+    }
 }


### PR DESCRIPTION
## Summary

- Block all forward calls from `AvsOperator` proxies to EigenLayer's `AllocationManager`, closing the slashing onramp at the contract level
- Add `blockedAllocationManager` state variable (write-once via `initializeV2`, no setter — removal requires a full UUPS upgrade)
- Guard `adminForwardCall`, `_forwardOperatorCall`, and `updateAllowedOperatorCalls` with `SlashingPathBlocked` revert when target is the blocked address
- Add `DeployTierBUpgrade` script that deploys the new implementation and outputs `upgradeToAndCall` calldata for the proxy owner

### Why this is sufficient

EigenLayer enforces `msg.sender == operator` for `registerForOperatorSets`. Since each `AvsOperator` IS the registered operator, only calls FROM `AvsOperator` to `AllocationManager` are effective. `AvsOperator.forwardCall` is `managerOnly` — the only caller is `AvsOperatorManager`. Blocking at the manager covers the entire surface.

### Storage layout

`blockedAllocationManager` is appended at slot 259, after all existing state. Verified via `forge inspect` and fork-based upgrade test.

### Deployment

1. Set `ALLOCATION_MANAGER` in `DeployTierBUpgrade` to EigenLayer's mainnet proxy address
2. Run `forge script script/deploy.s.sol:DeployTierBUpgrade`
3. Execute `upgradeToAndCall(newImpl, initializeV2(allocationManager))` from the proxy owner

## Test plan

- [x] `test_adminForwardCallBlocksAllocationManager` — admin targets AllocationManager, reverts
- [x] `test_forwardOperatorCallBlocksAllocationManager` — operator targets AllocationManager, reverts
- [x] `test_forwardOperatorCallRawInputBlocksAllocationManager` — raw-input overload, reverts
- [x] `test_updateAllowedOperatorCallsBlocksAllocationManager` — whitelisting blocked target, reverts
- [x] `test_updateAllowedOperatorCallsAllowsRemovingBlockedTarget` — un-whitelisting still works
- [x] `test_normalAdminForwardCallStillWorks` — non-blocked target succeeds
- [x] `test_normalForwardOperatorCallStillWorks` — non-blocked target succeeds
- [x] `test_initializeV2CannotBeCalledTwice` — reinitializer(2) is one-shot
- [x] `test_initializeV2OnlyOwner` — non-owner cannot call
- [x] `test_blockIsInactiveBeforeInitializeV2` — no block before initialization
- [x] `test_upgradeV2PreservesStorageAndSetsBlock` — fork test: storage preserved + block active
- [ ] External audit (narrow scope: single contract, ~10 lines of logic)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upgradeable contract storage and the core call-forwarding paths; a misconfigured `blockedAllocationManager` or upgrade execution could unintentionally break legitimate forwarded calls.
> 
> **Overview**
> Adds a **Tier B contract-level kill switch** in `AvsOperatorManager` to prevent any forwarded calls (including admin overrides and whitelist additions) from targeting EigenLayer’s `AllocationManager`, reverting with `SlashingPathBlocked` once activated.
> 
> Introduces a write-once `blockedAllocationManager` set via `initializeV2` (`reinitializer(2)`) and a deployment script (`DeployTierBUpgrade`) that deploys the new manager implementation and prints `upgradeToAndCall` calldata; expands tests to cover blocking behavior, one-shot initialization, and a fork-based upgrade/storage preservation check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76450947328330384fc595da176bdd52bb0ddd9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->